### PR TITLE
should propagate rejection

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules

--- a/index.js
+++ b/index.js
@@ -7,7 +7,9 @@ module.exports = function(Promise) {
       if (!condition()) return resolver.resolve();
       return Promise.cast(action())
         .then(loop)
-        .catch(resolver.reject);
+        .catch(function (e) {
+          resolver.reject(e);
+        });
     };
 
     process.nextTick(loop);

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
   "license": "ISC",
   "devDependencies": {
     "bluebird": "^2.9.6",
-    "mocha": "^2.1.0"
+    "mocha": "^2.1.0",
+    "should": "^7.1.1"
   }
 }

--- a/test/while.js
+++ b/test/while.js
@@ -1,21 +1,46 @@
-var Promise      = require('bluebird')
-var promiseWhile = require(__dirname+'/../')(Promise) 
+var Promise = require('bluebird');
+var promiseWhile = require(__dirname + '/../')(Promise);
+var should = require('should');
 
-describe('Promise While', function() {
+describe('Promise While', function () {
 
-  it('should loop three times asynchronously', function(done) {
+  it('should loop three times asynchronously', function (done) {
     var i = 0;
 
-    promiseWhile(function() { return i < 3 },
-      function() {
-        return new Promise(function(resolve, reject) {
-          setTimeout(function() {
-            console.log('aye', i)
-            resolve(i++)
+    promiseWhile(function () {
+        return i < 3
+      },
+      function () {
+        return new Promise(function (resolve, reject) {
+          setTimeout(function () {
+            console.log('aye', i);
+            resolve(i++);
           }, 500)
         })
-    })
-    .then(function() { done() })
+      })
+      .then(function () {
+        done();
+      })
   });
-})
+
+  it('should propagate rejection', function (done) {
+
+    function TestError() {}
+
+    promiseWhile(function () {
+        return true;
+      },
+      function () {
+        return new Promise(function (resolve, reject) {
+          reject(new TestError());
+        });
+      })
+      .catch(function (err) {
+        err.should.be.instanceof(TestError);
+        done();
+      })
+    ;
+  });
+
+});
 


### PR DESCRIPTION
current implementation doesn't propagate rejection from `action` correctly ... or maybe I'm doing something wrong. Here's test and fix.
